### PR TITLE
Add lookups for operations + operation logs and GHA examples

### DIFF
--- a/examples/aptible.py
+++ b/examples/aptible.py
@@ -1,0 +1,15 @@
+PROCFILE = """
+web: exec bundle exec unicorn -c config/unicorn.rb -p $PORT
+crons: exec supercronic -passthrough-logs crontabs/crontab
+sidekiq: exec bundle exec sidekiq -q default
+"""
+
+APTIBLE_YAML = """
+before_deploy:
+  - if [ -n "$DB_CREATE" ]; then bundle exec rake db:create; fi
+  - if [ -n "$RUN_MIGRATIONS" ]; then bundle exec rake db:migrate; fi
+after_deploy_success:
+  - ./alert_slack_success.sh
+after_deploy_failure:
+  - ./alert_slack_failure.sh
+"""

--- a/examples/github_actions.py
+++ b/examples/github_actions.py
@@ -1,0 +1,191 @@
+DEPROVISION_APP = """
+jobs:
+  deprovision-app:
+    name: Deprovision Review App and Databases
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install aptible CLI
+        run: |
+          PKG="$(mktemp)"
+          curl -fsSL "${{ env.CLI_URL }}" > "$PKG"
+          sudo dpkg -i "$PKG"
+          rm "$PKG"
+          aptible login --email "${{ secrets.APTIBLE_ROBOT_USERNAME }}" --password "${{ secrets.APTIBLE_ROBOT_PASSWORD }}"
+
+      - name: Deprovision app
+        run: |
+          aptible apps:deprovision --app ${{ vars.APTIBLE_APP_NAME }} --environment ${{ vars.APTIBLE_ENVIRONMENT_NAME }} || exit 0
+"""
+
+PROVISION_APP = """
+jobs:
+  deprovision-app:
+    name: Deprovision Review App and Databases
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install aptible CLI
+        run: |
+          PKG="$(mktemp)"
+          curl -fsSL "${{ env.CLI_URL }}" > "$PKG"
+          sudo dpkg -i "$PKG"
+          rm "$PKG"
+          aptible login --email "${{ secrets.APTIBLE_ROBOT_USERNAME }}" --password "${{ secrets.APTIBLE_ROBOT_PASSWORD }}"
+      - name: Find or create API App
+        run: aptible apps:create --environment ${{ vars.APTIBLE_ENVIRONMENT_NAME }} ${{ vars.APTIBLE_APP_NAME }} || exit 0
+"""
+
+CONFIGURE_APP = """
+jobs:
+  deprovision-app:
+    name: Deprovision Review App and Databases
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install aptible CLI
+        run: |
+          PKG="$(mktemp)"
+          curl -fsSL "${{ env.CLI_URL }}" > "$PKG"
+          sudo dpkg -i "$PKG"
+          rm "$PKG"
+          aptible login --email "${{ secrets.APTIBLE_ROBOT_USERNAME }}" --password "${{ secrets.APTIBLE_ROBOT_PASSWORD }}"
+      - name: Configure app
+        run: |
+          aptible config:set --environment ${{ vars.APTIBLE_ENVIRONMENT_NAME }} --app ${{ env.APTIBLE_API_APP_NAME }} \
+            DATABASE_URL="${{ env.PG_DATABASE_URL }}" \
+            CELERY_BROKER_URL="${{ env.REDIS_DATABASE_URL }}" \
+            FORCE_SSL=true \
+            SECRET_KEY=${{ secrets.SECRET_KEY }} \
+            FIELD_ENCRYPTION_KEYS=${{ secrets.FIELD_ENCRYPTION_KEYS }} \
+            IDLE_TIMEOUT=90
+"""
+
+DEPROVISION_DATABASE = """
+jobs:
+  deprovision-app:
+    name: Deprovision Review App and Databases
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install aptible CLI
+        run: |
+          PKG="$(mktemp)"
+          curl -fsSL "${{ env.CLI_URL }}" > "$PKG"
+          sudo dpkg -i "$PKG"
+          rm "$PKG"
+          aptible login --email "${{ secrets.APTIBLE_ROBOT_USERNAME }}" --password "${{ secrets.APTIBLE_ROBOT_PASSWORD }}"
+      - name: Deprovision database
+        run: |
+          aptible db:deprovision ${{ vars.DATABASE_NAME }} --environment ${{ vars.APTIBLE_ENVIRONMENT_NAME }} || exit 0
+"""
+
+PROVISION_DATABASE = """
+jobs:
+  build-publish-deploy:
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install aptible CLI
+        run: |
+          PKG="$(mktemp)"
+          curl -fsSL "${{ env.CLI_URL }}" > "$PKG"
+          sudo dpkg -i "$PKG"
+          rm "$PKG"
+          aptible login --email "${{ secrets.APTIBLE_ROBOT_USERNAME }}" --password "${{ secrets.APTIBLE_ROBOT_PASSWORD }}"
+      - name: Create PostgreSQL database
+        run: |
+          aptible db:create "${{ vars.DATABASE_NAME }}" --environment ${{ vars.APTIBLE_ENVIRONMENT_NAME }} --type postgresql || true
+      - name: Set PostgreSQL database env var
+        run: |
+          PG_DATABASE_URL=$(APTIBLE_OUTPUT_FORMAT=json aptible db:list --environment ${{ vars.APTIBLE_ENVIRONMENT_NAME }} | jq -r '.[] | select(.handle=="${{ vars.DATABASE_NAME }}")| .connection_url')
+          echo "PG_DATABASE_URL=$PG_DATABASE_URL" >> $GITHUB_ENV || exit 0
+"""
+
+RESTORE_FROM_BACKUP = """
+jobs:
+  build-publish-deploy:
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install aptible CLI
+        run: |
+          PKG="$(mktemp)"
+          curl -fsSL "${{ env.CLI_URL }}" > "$PKG"
+          sudo dpkg -i "$PKG"
+          rm "$PKG"
+          aptible login --email "${{ secrets.APTIBLE_ROBOT_USERNAME }}" --password "${{ secrets.APTIBLE_ROBOT_PASSWORD }}"
+
+      - name: Get most recent backup
+        run: |
+          BACKUP_ID=$(aptible backup:list ${{ vars.DATABASE_NAME }} --environment ${{ vars.APTIBLE_ENVIRONMENT_NAME }} | head -n 1 | awk -F ':' '{print $1}')
+          aptible backup:restore ${BACKUP_ID} --handle ${{ vars.DATABASE_NAME }}-restore
+"""
+
+PROVISION_ENDPOINT = """
+jobs:
+  deprovision-app:
+    name: Deprovision Review App and Databases
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install aptible CLI
+        run: |
+          PKG="$(mktemp)"
+          curl -fsSL "${{ env.CLI_URL }}" > "$PKG"
+          sudo dpkg -i "$PKG"
+          rm "$PKG"
+          aptible login --email "${{ secrets.APTIBLE_ROBOT_USERNAME }}" --password "${{ secrets.APTIBLE_ROBOT_PASSWORD }}"
+      - name: Create app endpoint
+        run: |
+          aptible endpoints:https:create --environment ${{ vars.APTIBLE_ENVIRONMENT_NAME }} --app ${{ vars.APTIBLE_APP_NAME }} --default-domain "cmd" --ip-whitelist ${{ vars.SAFE_IP_1 }} ${{ vars.SAFE_IP_2 }}  || exit 0
+"""
+
+BUILD_PUBLISH_DEPLOY = """
+jobs:
+  build-publish-deploy:
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install aptible CLI
+        run: |
+          PKG="$(mktemp)"
+          curl -fsSL "${{ env.CLI_URL }}" > "$PKG"
+          sudo dpkg -i "$PKG"
+          rm "$PKG"
+          aptible login --email "${{ secrets.APTIBLE_ROBOT_USERNAME }}" --password "${{ secrets.APTIBLE_ROBOT_PASSWORD }}"
+
+      - name: Log in to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Deploy to Aptible
+        uses: aptible/aptible-deploy-action@v4
+        with:
+          username: ${{ secrets.APTIBLE_ROBOT_USERNAME }}
+          password: ${{ secrets.APTIBLE_ROBOT_PASSWORD }}
+          environment: ${{ vars.APTIBLE_ENVIRONMENT_NAME }}
+          app: ${{ vars.APTIBLE_APP_NAME }}
+          docker_img: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          private_registry_username: ${{ github.actor }}
+          private_registry_password: ${{ secrets.GITHUB_TOKEN }}
+"""

--- a/examples/github_actions.py
+++ b/examples/github_actions.py
@@ -19,8 +19,8 @@ jobs:
 
 PROVISION_APP = """
 jobs:
-  deprovision-app:
-    name: Deprovision Review App and Databases
+  provision-app:
+    name: Provision Review App
     runs-on: ubuntu-24.04
     steps:
       - name: Install aptible CLI
@@ -36,8 +36,8 @@ jobs:
 
 CONFIGURE_APP = """
 jobs:
-  deprovision-app:
-    name: Deprovision Review App and Databases
+  configure-app:
+    name: Configure App
     runs-on: ubuntu-24.04
     steps:
       - name: Install aptible CLI
@@ -60,8 +60,8 @@ jobs:
 
 DEPROVISION_DATABASE = """
 jobs:
-  deprovision-app:
-    name: Deprovision Review App and Databases
+  deprovision-database:
+    name: Deprovision Database
     runs-on: ubuntu-24.04
     steps:
       - name: Install aptible CLI
@@ -122,8 +122,8 @@ jobs:
 
 PROVISION_ENDPOINT = """
 jobs:
-  deprovision-app:
-    name: Deprovision Review App and Databases
+  provision-endpoint:
+    name: Provision App Endpoint
     runs-on: ubuntu-24.04
     steps:
       - name: Install aptible CLI

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from mcp.server.fastmcp import FastMCP
 from typing import Any, Dict, List, Optional
 
 from api_client import AptibleApiClient
+from examples import aptible, github_actions
 from models import (
     AccountManager,
     App,
@@ -13,7 +14,6 @@ from models import (
     VhostManager,
 )
 from models.service import Service, ServiceManager
-
 
 mcp = FastMCP("aptible")
 
@@ -462,6 +462,95 @@ async def get_operation_logs(operation_id: int) -> str:
     """
     logs = await operation_manager.logs(operation_id)
     return logs
+
+
+@mcp.tool()
+async def get_procfile_example() -> str:
+    """
+    Gets an example Procfile for defining app processes.
+    Keep in mind that 1-off tasks like running migrations are better suited
+    for processes run via .aptible.yml, and do not belong in the Procfile.
+
+
+    The finalized Procfile file should be located in /.aptible/Procfile
+    in the build Docker image.
+    """
+    return aptible.PROCFILE
+
+
+@mcp.tool()
+async def get_aptible_yaml_example() -> str:
+    """
+    Gets an example aptible.yml configuration file for deploy hooks.
+
+    The finalized .aptible.yml file should be located in /.aptible/.aptible.yml
+    in the build Docker image.
+    """
+    return aptible.APTIBLE_YAML
+
+
+@mcp.tool()
+async def get_endpoint_provision_example() -> str:
+    """
+    Gets an example of a GitHub Action for provisioning an endpoint.
+    """
+    return github_actions.PROVISION_ENDPOINT
+
+
+@mcp.tool()
+async def get_app_provision_example() -> str:
+    """
+    Gets an example of a GitHub Action for provisioning an app.
+    """
+    return github_actions.PROVISION_APP
+
+
+@mcp.tool()
+async def get_app_deprovision_example() -> str:
+    """
+    Gets an example of a GitHub Action for deprovisioning an app.
+    """
+    return github_actions.DEPROVISION_APP
+
+
+@mcp.tool()
+async def get_app_configure_example() -> str:
+    """
+    Gets an example of a GitHub Action for configuring an app.
+    """
+    return github_actions.CONFIGURE_APP
+
+
+@mcp.tool()
+async def get_database_provision_example() -> str:
+    """
+    Gets an example of a GitHub Action for provisioning a database.
+    """
+    return github_actions.PROVISION_DATABASE
+
+
+@mcp.tool()
+async def get_database_deprovision_example() -> str:
+    """
+    Gets an example of a GitHub Action for deprovisioning a database.
+    """
+    return github_actions.DEPROVISION_DATABASE
+
+
+@mcp.tool()
+async def get_database_restore_example() -> str:
+    """
+    Gets an example of a GitHub Action for restoring a database from backup.
+    """
+    return github_actions.RESTORE_FROM_BACKUP
+
+
+@mcp.tool()
+async def get_build_deploy_example() -> str:
+    """
+    Gets an example of a GitHub Action for building, publishing, and deploying an app.
+    """
+    return github_actions.BUILD_PUBLISH_DEPLOY
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from models import (
     AppManager,
     Database,
     DatabaseManager,
+    OperationManager,
     StackManager,
     VhostManager,
 )
@@ -23,6 +24,7 @@ api_client = AptibleApiClient()
 account_manager = AccountManager(api_client)
 app_manager = AppManager(api_client)
 database_manager = DatabaseManager(api_client)
+operation_manager = OperationManager(api_client)
 stack_manager = StackManager(api_client)
 service_manager = ServiceManager(api_client)
 vhost_manager = VhostManager(api_client)
@@ -410,6 +412,56 @@ async def list_service_vhosts(
 
     vhosts = await vhost_manager.list_by_service(service.id)
     return [vhost.model_dump() for vhost in vhosts]
+
+
+@mcp.tool()
+async def get_operations_for_app(
+    app_handle: str, account_handle: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """
+    Get recent operations for a specific app.
+    """
+    app_data = await get_app(app_handle, account_handle)
+    if not app_data:
+        raise Exception(f"App {app_handle} not found.")
+
+    app = App.model_validate(app_data)
+    operations = await operation_manager.get_operations_for_app(app.id)
+    return operations
+
+
+@mcp.tool()
+async def get_operations_for_database(
+    database_handle: str, account_handle: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """
+    Get recent operations for a specific database.
+    """
+    database_data = await get_database(database_handle, account_handle)
+    if not database_data:
+        raise Exception(f"Database {database_handle} not found.")
+
+    database = Database.model_validate(database_data)
+    operations = await operation_manager.get_operations_for_database(database.id)
+    return operations
+
+
+@mcp.tool()
+async def get_operations_for_vhost(vhost_id: int) -> List[Dict[str, Any]]:
+    """
+    Get recent operations for a specific vhost/endpoint.
+    """
+    operations = await operation_manager.get_operations_for_vhost(vhost_id)
+    return operations
+
+
+@mcp.tool()
+async def get_operation_logs(operation_id: int) -> str:
+    """
+    Get logs for a specific operation.
+    """
+    logs = await operation_manager.logs(operation_id)
+    return logs
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ app_manager.service_manager = service_manager
 
 
 @mcp.tool()
-async def list_accounts() -> List[Dict[str, Any]]:
+async def listAccounts() -> List[Dict[str, Any]]:
     """
     List all accounts/environments.
     """
@@ -41,7 +41,7 @@ async def list_accounts() -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def get_account(account_handle: str) -> Optional[Dict[str, Any]]:
+async def getAccount(account_handle: str) -> Optional[Dict[str, Any]]:
     """
     Get account/environment by handle.
     """
@@ -50,7 +50,7 @@ async def get_account(account_handle: str) -> Optional[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def get_accounts_by_stack(stack_name: str) -> List[Dict[str, Any]]:
+async def getAccountsByStack(stack_name: str) -> List[Dict[str, Any]]:
     """
     Get all accounts/environments in a stack by stack name.
     """
@@ -63,7 +63,7 @@ async def get_accounts_by_stack(stack_name: str) -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def create_account(account_name: str, stack_name: str) -> Dict[str, Any]:
+async def createAccount(account_name: str, stack_name: str) -> Dict[str, Any]:
     """
     Create a new account/environment.
     """
@@ -76,7 +76,7 @@ async def create_account(account_name: str, stack_name: str) -> Dict[str, Any]:
 
 
 @mcp.tool()
-async def list_apps() -> List[Dict[str, Any]]:
+async def listApps() -> List[Dict[str, Any]]:
     """
     List all apps.
     """
@@ -85,7 +85,7 @@ async def list_apps() -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def get_app(
+async def getApp(
     app_handle: str, account_handle: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
     """
@@ -123,7 +123,7 @@ async def get_app(
 
 
 @mcp.tool()
-async def create_app(
+async def createApp(
     app_handle: str, account_handle: str, docker_image: str
 ) -> Dict[str, Any]:
     """
@@ -142,13 +142,13 @@ async def create_app(
 
 
 @mcp.tool()
-async def configure_app(
+async def configureApp(
     app_handle: str, account_handle: Optional[str], env: Dict[str, str]
 ) -> None:
     """
     Configure app environment variables.
     """
-    app_data = await get_app(app_handle, account_handle)
+    app_data = await getApp(app_handle, account_handle)
     if not app_data:
         raise Exception(f"App {app_handle} not found.")
 
@@ -157,11 +157,11 @@ async def configure_app(
 
 
 @mcp.tool()
-async def delete_app(app_handle: str, account_handle: Optional[str] = None) -> None:
+async def deleteApp(app_handle: str, account_handle: Optional[str] = None) -> None:
     """
     Delete an app.
     """
-    app_data = await get_app(app_handle, account_handle)
+    app_data = await getApp(app_handle, account_handle)
     if not app_data:
         raise Exception(f"App {app_handle} not found.")
 
@@ -170,7 +170,7 @@ async def delete_app(app_handle: str, account_handle: Optional[str] = None) -> N
 
 
 @mcp.tool()
-async def list_available_database_types() -> List[Dict[str, Any]]:
+async def listAvailableDatabaseTypes() -> List[Dict[str, Any]]:
     """
     List all available database types. When creating a database,
     the image id provided via this method is needed.
@@ -180,7 +180,7 @@ async def list_available_database_types() -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def list_databases() -> List[Dict[str, Any]]:
+async def listDatabases() -> List[Dict[str, Any]]:
     """
     List all databases.
     """
@@ -189,7 +189,7 @@ async def list_databases() -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def get_database(
+async def getDatabase(
     database_handle: str, account_handle: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
     """
@@ -224,12 +224,12 @@ async def get_database(
 
 
 @mcp.tool()
-async def create_database(
+async def createDatabase(
     database_handle: str, account_handle: str, image_id: int
 ) -> Dict[str, Any]:
     """
     Create a new database.
-    The image_id should be the ID found via list_available_database_types.
+    The image_id should be the ID found via listAvailableDatabaseTypes.
     """
     account = await account_manager.get(account_handle)
     if not account:
@@ -245,13 +245,13 @@ async def create_database(
 
 
 @mcp.tool()
-async def delete_database(
+async def deleteDatabase(
     database_handle: str, account_handle: Optional[str] = None
 ) -> None:
     """
     Delete a database.
     """
-    database_data = await get_database(database_handle, account_handle)
+    database_data = await getDatabase(database_handle, account_handle)
     if not database_data:
         raise Exception(f"Database {database_handle} not found.")
 
@@ -260,7 +260,7 @@ async def delete_database(
 
 
 @mcp.tool()
-async def list_stacks() -> List[Dict[str, Any]]:
+async def listStacks() -> List[Dict[str, Any]]:
     """
     List all stacks.
     """
@@ -269,7 +269,7 @@ async def list_stacks() -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def get_stack(stack_name: str) -> Optional[Dict[str, Any]]:
+async def getStack(stack_name: str) -> Optional[Dict[str, Any]]:
     """
     Get stack by name.
     """
@@ -278,7 +278,7 @@ async def get_stack(stack_name: str) -> Optional[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def list_vhosts() -> List[Dict[str, Any]]:
+async def listVhosts() -> List[Dict[str, Any]]:
     """
     List all vhosts/endpoints).
     """
@@ -287,7 +287,7 @@ async def list_vhosts() -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def get_vhost(vhost_id: str) -> Optional[Dict[str, Any]]:
+async def getVhost(vhost_id: str) -> Optional[Dict[str, Any]]:
     """
     Get vhost by ID.
     """
@@ -296,7 +296,7 @@ async def get_vhost(vhost_id: str) -> Optional[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def create_vhost(
+async def createVhost(
     app_handle: str, service_handle: str, account_handle: Optional[str] = None
 ) -> Dict[str, Any]:
     """
@@ -310,7 +310,7 @@ async def create_vhost(
           Currently, since there's no tools for handling DNS, we only
           support creating the default on-aptible.com domains for Services.
     """
-    app_data = await get_app(app_handle, account_handle)
+    app_data = await getApp(app_handle, account_handle)
     if not app_data:
         raise Exception(f"App {app_handle} not found.")
 
@@ -330,7 +330,7 @@ async def create_vhost(
 
 
 @mcp.tool()
-async def delete_vhost(vhost_id: int) -> None:
+async def deleteVhost(vhost_id: int) -> None:
     """
     Delete a vhost/endpoint.
     """
@@ -338,13 +338,13 @@ async def delete_vhost(vhost_id: int) -> None:
 
 
 @mcp.tool()
-async def list_services(
+async def listServices(
     app_handle: str, account_handle: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """
     List all services for a specific app.
     """
-    app_data = await get_app(app_handle, account_handle)
+    app_data = await getApp(app_handle, account_handle)
     if not app_data:
         raise Exception(f"App {app_handle} not found.")
 
@@ -354,13 +354,13 @@ async def list_services(
 
 
 @mcp.tool()
-async def get_service(
+async def getService(
     app_handle: str, service_handle: str, account_handle: Optional[str] = None
 ) -> Dict[str, Any]:
     """
     Get a service by handle within a specific app.
     """
-    app_data = await get_app(app_handle, account_handle)
+    app_data = await getApp(app_handle, account_handle)
     if not app_data:
         raise Exception(f"App {app_handle} not found.")
 
@@ -376,7 +376,7 @@ async def get_service(
 
 
 @mcp.tool()
-async def scale_service(
+async def scaleService(
     app_handle: str,
     service_handle: str,
     container_count: Optional[int] = None,
@@ -391,7 +391,7 @@ async def scale_service(
             "Must specify at least one of container_count or container_size"
         )
 
-    service_data = await get_service(app_handle, service_handle, account_handle)
+    service_data = await getService(app_handle, service_handle, account_handle)
     service = Service.model_validate(service_data)
 
     updated_service = await service_manager.scale(
@@ -401,13 +401,13 @@ async def scale_service(
 
 
 @mcp.tool()
-async def list_service_vhosts(
+async def listServiceVhosts(
     app_handle: str, service_handle: str, account_handle: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """
     List all vhosts for a specific service.
     """
-    service_data = await get_service(app_handle, service_handle, account_handle)
+    service_data = await getService(app_handle, service_handle, account_handle)
     service = Service.model_validate(service_data)
 
     vhosts = await vhost_manager.list_by_service(service.id)
@@ -415,13 +415,13 @@ async def list_service_vhosts(
 
 
 @mcp.tool()
-async def get_operations_for_app(
+async def getOperationsForApp(
     app_handle: str, account_handle: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """
     Get recent operations for a specific app.
     """
-    app_data = await get_app(app_handle, account_handle)
+    app_data = await getApp(app_handle, account_handle)
     if not app_data:
         raise Exception(f"App {app_handle} not found.")
 
@@ -431,13 +431,13 @@ async def get_operations_for_app(
 
 
 @mcp.tool()
-async def get_operations_for_database(
+async def getOperationsForDatabase(
     database_handle: str, account_handle: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """
     Get recent operations for a specific database.
     """
-    database_data = await get_database(database_handle, account_handle)
+    database_data = await getDatabase(database_handle, account_handle)
     if not database_data:
         raise Exception(f"Database {database_handle} not found.")
 
@@ -447,7 +447,7 @@ async def get_operations_for_database(
 
 
 @mcp.tool()
-async def get_operations_for_vhost(vhost_id: int) -> List[Dict[str, Any]]:
+async def getOperationsForVhost(vhost_id: int) -> List[Dict[str, Any]]:
     """
     Get recent operations for a specific vhost/endpoint.
     """
@@ -456,7 +456,7 @@ async def get_operations_for_vhost(vhost_id: int) -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
-async def get_operation_logs(operation_id: int) -> str:
+async def getOperationLogs(operation_id: int) -> str:
     """
     Get logs for a specific operation.
     """
@@ -465,7 +465,7 @@ async def get_operation_logs(operation_id: int) -> str:
 
 
 @mcp.tool()
-async def get_procfile_example() -> str:
+async def getProcfileExample() -> str:
     """
     Gets an example Procfile for defining app processes.
     Keep in mind that 1-off tasks like running migrations are better suited
@@ -479,7 +479,7 @@ async def get_procfile_example() -> str:
 
 
 @mcp.tool()
-async def get_aptible_yaml_example() -> str:
+async def getAptibleYamlExample() -> str:
     """
     Gets an example aptible.yml configuration file for deploy hooks.
 
@@ -490,7 +490,7 @@ async def get_aptible_yaml_example() -> str:
 
 
 @mcp.tool()
-async def get_endpoint_provision_example() -> str:
+async def getEndpointProvisionExample() -> str:
     """
     Gets an example of a GitHub Action for provisioning an endpoint.
     """
@@ -498,7 +498,7 @@ async def get_endpoint_provision_example() -> str:
 
 
 @mcp.tool()
-async def get_app_provision_example() -> str:
+async def getAppProvisionExample() -> str:
     """
     Gets an example of a GitHub Action for provisioning an app.
     """
@@ -506,7 +506,7 @@ async def get_app_provision_example() -> str:
 
 
 @mcp.tool()
-async def get_app_deprovision_example() -> str:
+async def getAppDeprovisionExample() -> str:
     """
     Gets an example of a GitHub Action for deprovisioning an app.
     """
@@ -514,7 +514,7 @@ async def get_app_deprovision_example() -> str:
 
 
 @mcp.tool()
-async def get_app_configure_example() -> str:
+async def getAppConfigureExample() -> str:
     """
     Gets an example of a GitHub Action for configuring an app.
     """
@@ -522,7 +522,7 @@ async def get_app_configure_example() -> str:
 
 
 @mcp.tool()
-async def get_database_provision_example() -> str:
+async def getDatabaseProvisionExample() -> str:
     """
     Gets an example of a GitHub Action for provisioning a database.
     """
@@ -530,7 +530,7 @@ async def get_database_provision_example() -> str:
 
 
 @mcp.tool()
-async def get_database_deprovision_example() -> str:
+async def getDatabaseDeprovisionExample() -> str:
     """
     Gets an example of a GitHub Action for deprovisioning a database.
     """
@@ -538,7 +538,7 @@ async def get_database_deprovision_example() -> str:
 
 
 @mcp.tool()
-async def get_database_restore_example() -> str:
+async def getDatabaseRestoreExample() -> str:
     """
     Gets an example of a GitHub Action for restoring a database from backup.
     """
@@ -546,7 +546,7 @@ async def get_database_restore_example() -> str:
 
 
 @mcp.tool()
-async def get_build_deploy_example() -> str:
+async def getBuildDeployExample() -> str:
     """
     Gets an example of a GitHub Action for building, publishing, and deploying an app.
     """

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,7 @@
 from models.account import Account, AccountManager
 from models.app import App, AppManager
 from models.database import Database, DatabaseImage, DatabaseManager
+from models.operation import Operation, OperationManager
 from models.service import Service, ServiceManager
 from models.stack import Stack, StackManager
 from models.vhost import Vhost, VhostManager
@@ -14,6 +15,8 @@ __all__ = [
     "Database",
     "DatabaseImage",
     "DatabaseManager",
+    "Operation",
+    "OperationManager",
     "Service",
     "ServiceManager",
     "Stack",

--- a/models/operation.py
+++ b/models/operation.py
@@ -51,11 +51,8 @@ class OperationManager(ResourceManager[Operation, str]):
             if not log_response.content:
                 return f"No logs available for operation {operation_id} (empty content from redirect URL)"
             return log_response.text
-        else:
-            # Unexpected status code
-            raise Exception(
-                f"Unexpected status code {response.status_code} for operation {operation_id} logs"
-            )
+
+        return ""
 
     async def get_operations_for_app(self, app_id: int) -> List[Dict[str, Any]]:
         """

--- a/models/operation.py
+++ b/models/operation.py
@@ -1,0 +1,104 @@
+from pydantic import Field
+import requests
+from typing import Dict, List, Any
+
+from models.base import ResourceBase, ResourceManager
+
+
+class Operation(ResourceBase):
+    """
+    Database Images available for managed databases.
+    """
+
+    resource_id: int = Field(
+        ..., description="ID of the resource the operation was run against."
+    )
+    resource_type: str = Field(
+        ..., description="Type of the resource the operation was run against."
+    )
+    type: str = Field(..., description="The type of operation run.")
+
+
+class OperationManager(ResourceManager[Operation, str]):
+    """
+    Manager for Operations.
+    """
+
+    resource_name = "operations"
+    resource_model = Operation
+    resource_url = "/operations"
+
+    async def logs(self, operation_id: int) -> str:
+        """
+        Get logs for an operation by fetching from the S3 URL endpoint.
+        Returns the actual log content as a string.
+        """
+        # Make the request directly without going through api_client to handle non-JSON responses
+        url = f"{self.api_client.api_url}/operations/{operation_id}/logs"
+        headers = self.api_client._get_headers()
+
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+
+        if not response.content:
+            return f"No logs available for operation {operation_id} (empty response)"
+
+        if response.status_code == 200:
+            redirect_url = response.text
+            log_response = requests.get(redirect_url)
+            log_response.raise_for_status()
+            if not log_response.content:
+                return f"No logs available for operation {operation_id} (empty content from redirect URL)"
+            return log_response.text
+        else:
+            # Unexpected status code
+            raise Exception(
+                f"Unexpected status code {response.status_code} for operation {operation_id} logs"
+            )
+
+    async def get_operations_for_app(self, app_id: int) -> List[Dict[str, Any]]:
+        """
+        Get recent operations for an app with ID, type, and status.
+        """
+        response = self.api_client.get(f"/apps/{app_id}/operations")
+        operations = response.get("_embedded", {}).get("operations", [])
+        return [
+            {
+                "id": op["id"],
+                "type": op.get("type", "unknown"),
+                "status": op.get("status", "unknown"),
+            }
+            for op in operations
+        ]
+
+    async def get_operations_for_database(
+        self, database_id: int
+    ) -> List[Dict[str, Any]]:
+        """
+        Get recent operations for a database with ID, type, and status.
+        """
+        response = self.api_client.get(f"/databases/{database_id}/operations")
+        operations = response.get("_embedded", {}).get("operations", [])
+        return [
+            {
+                "id": op["id"],
+                "type": op.get("type", "unknown"),
+                "status": op.get("status", "unknown"),
+            }
+            for op in operations
+        ]
+
+    async def get_operations_for_vhost(self, vhost_id: int) -> List[Dict[str, Any]]:
+        """
+        Get recent operations for a vhost with ID, type, and status.
+        """
+        response = self.api_client.get(f"/vhosts/{vhost_id}/operations")
+        operations = response.get("_embedded", {}).get("operations", [])
+        return [
+            {
+                "id": op["id"],
+                "type": op.get("type", "unknown"),
+                "status": op.get("status", "unknown"),
+            }
+            for op in operations
+        ]

--- a/models/operation.py
+++ b/models/operation.py
@@ -7,7 +7,7 @@ from models.base import ResourceBase, ResourceManager
 
 class Operation(ResourceBase):
     """
-    Database Images available for managed databases.
+    Aptible Operation model.
     """
 
     resource_id: int = Field(
@@ -33,7 +33,8 @@ class OperationManager(ResourceManager[Operation, str]):
         Get logs for an operation by fetching from the S3 URL endpoint.
         Returns the actual log content as a string.
         """
-        # Make the request directly without going through api_client to handle non-JSON responses
+        # Make the request directly without going through api_client
+        # since the result is not JSON.
         url = f"{self.api_client.api_url}/operations/{operation_id}/logs"
         headers = self.api_client._get_headers()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,30 +9,30 @@ from models.stack import Stack
 from models.database import DatabaseImage
 from models.vhost import Vhost
 from main import (
-    list_accounts,
-    get_account,
-    get_accounts_by_stack,
-    create_account,
-    list_stacks,
-    get_stack,
-    list_apps,
-    get_app,
-    create_app,
-    configure_app,
-    delete_app,
-    list_available_database_types,
-    list_databases,
-    get_database,
-    create_database,
-    delete_database,
-    list_vhosts,
-    get_vhost,
-    create_vhost,
-    delete_vhost,
-    list_services,
-    get_service,
-    scale_service,
-    list_service_vhosts,
+    listAccounts,
+    getAccount,
+    getAccountsByStack,
+    createAccount,
+    listStacks,
+    getStack,
+    listApps,
+    getApp,
+    createApp,
+    configureApp,
+    deleteApp,
+    listAvailableDatabaseTypes,
+    listDatabases,
+    getDatabase,
+    createDatabase,
+    deleteDatabase,
+    listVhosts,
+    getVhost,
+    createVhost,
+    deleteVhost,
+    listServices,
+    getService,
+    scaleService,
+    listServiceVhosts,
 )
 
 
@@ -113,7 +113,7 @@ async def test_list_accounts(mock_account_manager):
     ]
     mock_account_manager.list = AsyncMock(return_value=mock_accounts)
 
-    result = await list_accounts()
+    result = await listAccounts()
     mock_account_manager.list.assert_called_once()
     assert len(result) == 2
     assert result[0]["id"] == 1
@@ -138,7 +138,7 @@ async def test_get_account_success(mock_account_manager):
     )
     mock_account_manager.get = AsyncMock(return_value=mock_account)
 
-    result = await get_account("test-account")
+    result = await getAccount("test-account")
     mock_account_manager.get.assert_called_once_with("test-account")
     assert result["id"] == 1
     assert result["handle"] == "test-account"
@@ -152,7 +152,7 @@ async def test_get_account_not_found(mock_account_manager):
     """
     mock_account_manager.get = AsyncMock(return_value=None)
 
-    result = await get_account("nonexistent-account")
+    result = await getAccount("nonexistent-account")
     mock_account_manager.get.assert_called_once_with("nonexistent-account")
     assert result is None
 
@@ -191,7 +191,7 @@ async def test_get_accounts_by_stack_success(mock_stack_manager, mock_account_ma
     ]
     mock_account_manager.get_by_stack_id = AsyncMock(return_value=mock_accounts)
 
-    result = await get_accounts_by_stack("test-stack")
+    result = await getAccountsByStack("test-stack")
 
     mock_stack_manager.get.assert_called_once_with("test-stack")
     mock_account_manager.get_by_stack_id.assert_called_once_with(123)
@@ -211,7 +211,7 @@ async def test_get_accounts_by_stack_not_found(mock_stack_manager):
     mock_stack_manager.get = AsyncMock(return_value=None)
 
     with pytest.raises(Exception) as excinfo:
-        await get_accounts_by_stack("nonexistent-stack")
+        await getAccountsByStack("nonexistent-stack")
 
     mock_stack_manager.get.assert_called_once_with("nonexistent-stack")
     assert "Stack nonexistent-stack not found" in str(excinfo.value)
@@ -242,7 +242,7 @@ async def test_create_account_success(mock_stack_manager, mock_account_manager):
     )
     mock_account_manager.create = AsyncMock(return_value=mock_account)
 
-    result = await create_account("new-account", "test-stack")
+    result = await createAccount("new-account", "test-stack")
 
     mock_stack_manager.get.assert_called_once_with("test-stack")
     mock_account_manager.create.assert_called_once_with(
@@ -261,7 +261,7 @@ async def test_create_account_stack_not_found(mock_stack_manager):
     mock_stack_manager.get = AsyncMock(return_value=None)
 
     with pytest.raises(Exception) as excinfo:
-        await create_account("new-account", "nonexistent-stack")
+        await createAccount("new-account", "nonexistent-stack")
 
     mock_stack_manager.get.assert_called_once_with("nonexistent-stack")
     assert "Stack nonexistent-stack not found" in str(excinfo.value)
@@ -294,7 +294,7 @@ async def test_list_stacks(mock_stack_manager):
     ]
     mock_stack_manager.list = AsyncMock(return_value=mock_stacks)
 
-    result = await list_stacks()
+    result = await listStacks()
 
     mock_stack_manager.list.assert_called_once()
     assert len(result) == 2
@@ -322,7 +322,7 @@ async def test_get_stack_success(mock_stack_manager):
     )
     mock_stack_manager.get = AsyncMock(return_value=mock_stack)
 
-    result = await get_stack("test-stack")
+    result = await getStack("test-stack")
 
     mock_stack_manager.get.assert_called_once_with("test-stack")
     assert result["id"] == 123
@@ -337,7 +337,7 @@ async def test_get_stack_not_found(mock_stack_manager):
     """
     mock_stack_manager.get = AsyncMock(return_value=None)
 
-    result = await get_stack("nonexistent-stack")
+    result = await getStack("nonexistent-stack")
 
     mock_stack_manager.get.assert_called_once_with("nonexistent-stack")
     assert result is None
@@ -368,7 +368,7 @@ async def test_list_apps(mock_app_manager):
     ]
     mock_app_manager.list = AsyncMock(return_value=mock_apps)
 
-    result = await list_apps()
+    result = await listApps()
 
     mock_app_manager.list.assert_called_once()
     assert len(result) == 2
@@ -396,7 +396,7 @@ async def test_get_app_single_match(mock_app_manager):
     ]
     mock_app_manager.list = AsyncMock(return_value=mock_apps)
 
-    result = await get_app("test-app")
+    result = await getApp("test-app")
 
     mock_app_manager.list.assert_called_once()
     assert result["id"] == 1
@@ -438,7 +438,7 @@ async def test_get_app_with_account(mock_app_manager, mock_account_manager):
     )
     mock_account_manager.get = AsyncMock(return_value=mock_account)
 
-    result = await get_app("test-app", "test-account")
+    result = await getApp("test-app", "test-account")
 
     mock_app_manager.list.assert_called_once()
     mock_account_manager.get.assert_called_once_with("test-account")
@@ -454,7 +454,7 @@ async def test_get_app_no_match(mock_app_manager):
     mock_app_manager.list = AsyncMock(return_value=[])
 
     with pytest.raises(Exception) as excinfo:
-        await get_app("nonexistent-app")
+        await getApp("nonexistent-app")
 
     mock_app_manager.list.assert_called_once()
     assert "No app with handle nonexistent-app" in str(excinfo.value)
@@ -486,7 +486,7 @@ async def test_get_app_multiple_matches_no_account(mock_app_manager):
     mock_app_manager.list = AsyncMock(return_value=mock_apps)
 
     with pytest.raises(Exception) as excinfo:
-        await get_app("test-app")
+        await getApp("test-app")
 
     mock_app_manager.list.assert_called_once()
     assert "Multiple apps found with handle test-app" in str(excinfo.value)
@@ -516,7 +516,7 @@ async def test_create_app_success(mock_app_manager, mock_account_manager):
     )
     mock_app_manager.create = AsyncMock(return_value=mock_app)
 
-    result = await create_app("new-app", "test-account", "example/image:latest")
+    result = await createApp("new-app", "test-account", "example/image:latest")
     mock_account_manager.get.assert_called_once_with("test-account")
     mock_app_manager.create.assert_called_once_with(
         {
@@ -538,7 +538,7 @@ async def test_create_app_account_not_found(mock_account_manager):
     mock_account_manager.get = AsyncMock(return_value=None)
 
     with pytest.raises(Exception) as excinfo:
-        await create_app("new-app", "nonexistent-account", "example/image:latest")
+        await createApp("new-app", "nonexistent-account", "example/image:latest")
 
     mock_account_manager.get.assert_called_once_with("nonexistent-account")
     assert "Account nonexistent-account not found" in str(excinfo.value)
@@ -560,12 +560,12 @@ async def test_configure_app_success(mock_app_manager):
 
     mock_app_manager.configure = AsyncMock()
 
-    with patch("main.get_app", new=AsyncMock(return_value=mock_app_data)):
+    with patch("main.getApp", new=AsyncMock(return_value=mock_app_data)):
         env_vars = {
             "DATABASE_URL": "postgres://user:pass@host:5432/db",
             "API_KEY": "secret-key",
         }
-        await configure_app("test-app", "test-account", env_vars)
+        await configureApp("test-app", "test-account", env_vars)
         mock_app_manager.configure.assert_called_once_with(1, env_vars)
 
 
@@ -574,9 +574,9 @@ async def test_configure_app_not_found():
     """
     Test configure_app raises an exception when app is not found.
     """
-    with patch("main.get_app", new=AsyncMock(return_value=None)):
+    with patch("main.getApp", new=AsyncMock(return_value=None)):
         with pytest.raises(Exception) as excinfo:
-            await configure_app("nonexistent-app", "test-account", {"KEY": "VALUE"})
+            await configureApp("nonexistent-app", "test-account", {"KEY": "VALUE"})
 
         assert "App nonexistent-app not found" in str(excinfo.value)
 
@@ -596,9 +596,9 @@ async def test_delete_app_success(mock_app_manager):
     }
 
     mock_app_manager.delete = AsyncMock()
-    with patch("main.get_app", new=AsyncMock(return_value=mock_app_data)):
+    with patch("main.getApp", new=AsyncMock(return_value=mock_app_data)):
         with patch("main.App.account_id", return_value=123):
-            await delete_app("test-app")
+            await deleteApp("test-app")
             mock_app_manager.delete.assert_called_once_with(1)
 
 
@@ -607,9 +607,9 @@ async def test_delete_app_not_found():
     """
     Test delete_app raises an exception when app is not found.
     """
-    with patch("main.get_app", new=AsyncMock(return_value=None)):
+    with patch("main.getApp", new=AsyncMock(return_value=None)):
         with pytest.raises(Exception) as excinfo:
-            await delete_app("nonexistent-app", "test-account")
+            await deleteApp("nonexistent-app", "test-account")
         assert "App nonexistent-app not found" in str(excinfo.value)
 
 
@@ -648,7 +648,7 @@ async def test_list_available_database_types(mock_database_manager):
     ]
     mock_database_manager.list_available_types = AsyncMock(return_value=mock_db_types)
 
-    result = await list_available_database_types()
+    result = await listAvailableDatabaseTypes()
 
     mock_database_manager.list_available_types.assert_called_once()
     assert len(result) == 2
@@ -693,7 +693,7 @@ async def test_list_databases(mock_database_manager):
     ]
     mock_database_manager.list = AsyncMock(return_value=mock_databases)
 
-    result = await list_databases()
+    result = await listDatabases()
 
     mock_database_manager.list.assert_called_once()
     assert len(result) == 2
@@ -725,7 +725,7 @@ async def test_get_database_single_match(mock_database_manager):
     ]
     mock_database_manager.list = AsyncMock(return_value=mock_databases)
 
-    result = await get_database("test-db")
+    result = await getDatabase("test-db")
 
     mock_database_manager.list.assert_called_once()
     assert result["id"] == 1
@@ -775,7 +775,7 @@ async def test_get_database_with_account(mock_database_manager, mock_account_man
     )
     mock_account_manager.get = AsyncMock(return_value=mock_account)
 
-    result = await get_database("test-db", "test-account")
+    result = await getDatabase("test-db", "test-account")
 
     mock_database_manager.list.assert_called_once()
     mock_account_manager.get.assert_called_once_with("test-account")
@@ -791,7 +791,7 @@ async def test_get_database_no_match(mock_database_manager):
     mock_database_manager.list = AsyncMock(return_value=[])
 
     with pytest.raises(Exception) as excinfo:
-        await get_database("nonexistent-db")
+        await getDatabase("nonexistent-db")
 
     mock_database_manager.list.assert_called_once()
     assert "No database with handle nonexistent-db" in str(excinfo.value)
@@ -831,7 +831,7 @@ async def test_get_database_multiple_matches_no_account(mock_database_manager):
     mock_database_manager.list = AsyncMock(return_value=mock_databases)
 
     with pytest.raises(Exception) as excinfo:
-        await get_database("test-db")
+        await getDatabase("test-db")
 
     mock_database_manager.list.assert_called_once()
     assert "Multiple databases found with handle test-db" in str(excinfo.value)
@@ -866,7 +866,7 @@ async def test_create_database_success(mock_database_manager, mock_account_manag
     )
     mock_database_manager.create = AsyncMock(return_value=mock_database)
 
-    result = await create_database("new-db", "test-account", 42)
+    result = await createDatabase("new-db", "test-account", 42)
     mock_account_manager.get.assert_called_once_with("test-account")
     mock_database_manager.create.assert_called_once_with(
         {
@@ -888,7 +888,7 @@ async def test_create_database_account_not_found(mock_account_manager):
     mock_account_manager.get = AsyncMock(return_value=None)
 
     with pytest.raises(Exception) as excinfo:
-        await create_database("new-db", "nonexistent-account", 42)
+        await createDatabase("new-db", "nonexistent-account", 42)
 
     mock_account_manager.get.assert_called_once_with("nonexistent-account")
     assert "Account nonexistent-account not found" in str(excinfo.value)
@@ -914,9 +914,9 @@ async def test_delete_database_success(mock_database_manager):
     # Use AsyncMock for the delete method to make it awaitable
     mock_database_manager.delete = AsyncMock()
 
-    with patch("main.get_database", new=AsyncMock(return_value=mock_database_data)):
+    with patch("main.getDatabase", new=AsyncMock(return_value=mock_database_data)):
         with patch("main.Database.account_id", return_value=123):
-            await delete_database("test-db", "test-account")
+            await deleteDatabase("test-db", "test-account")
             mock_database_manager.delete.assert_called_once_with(
                 mock_database_data["id"]
             )
@@ -927,9 +927,9 @@ async def test_delete_database_not_found():
     """
     Test delete_database raises an exception when database is not found.
     """
-    with patch("main.get_database", new=AsyncMock(return_value=None)):
+    with patch("main.getDatabase", new=AsyncMock(return_value=None)):
         with pytest.raises(Exception) as excinfo:
-            await delete_database("nonexistent-db", "test-account")
+            await deleteDatabase("nonexistent-db", "test-account")
 
         assert "Database nonexistent-db not found" in str(excinfo.value)
 
@@ -963,7 +963,7 @@ async def test_list_vhosts(mock_vhost_manager):
     ]
     mock_vhost_manager.list = AsyncMock(return_value=mock_vhosts)
 
-    result = await list_vhosts()
+    result = await listVhosts()
 
     mock_vhost_manager.list.assert_called_once()
     assert len(result) == 2
@@ -991,7 +991,7 @@ async def test_get_vhost_success(mock_vhost_manager):
     )
     mock_vhost_manager.get = AsyncMock(return_value=mock_vhost)
 
-    result = await get_vhost("1")
+    result = await getVhost("1")
 
     mock_vhost_manager.get.assert_called_once_with("1")
     assert result["id"] == 1
@@ -1006,7 +1006,7 @@ async def test_get_vhost_not_found(mock_vhost_manager):
     """
     mock_vhost_manager.get = AsyncMock(return_value=None)
 
-    result = await get_vhost("999")
+    result = await getVhost("999")
 
     mock_vhost_manager.get.assert_called_once_with("999")
     assert result is None
@@ -1067,8 +1067,8 @@ async def test_create_vhost_success(mock_service_manager, mock_vhost_manager):
     mock_service_manager.list_by_app = AsyncMock(return_value=mock_services)
     mock_vhost_manager.create = AsyncMock(return_value=mock_vhost)
 
-    with patch("main.get_app", new=AsyncMock(return_value=mock_app_data)):
-        result = await create_vhost("test-app", "web", "test-account")
+    with patch("main.getApp", new=AsyncMock(return_value=mock_app_data)):
+        result = await createVhost("test-app", "web", "test-account")
 
         mock_service_manager.list_by_app.assert_called_once_with(1)
         mock_vhost_manager.create.assert_called_once_with({"service_id": 123})
@@ -1084,9 +1084,9 @@ async def test_create_vhost_app_not_found():
     Test create_vhost raises an exception when app is not found.
     """
 
-    with patch("main.get_app", new=AsyncMock(return_value=None)):
+    with patch("main.getApp", new=AsyncMock(return_value=None)):
         with pytest.raises(Exception) as excinfo:
-            await create_vhost("nonexistent-app", "web", "test-account")
+            await createVhost("nonexistent-app", "web", "test-account")
 
         assert "App nonexistent-app not found" in str(excinfo.value)
 
@@ -1110,9 +1110,9 @@ async def test_create_vhost_service_not_found(mock_service_manager):
 
     mock_service_manager.list_by_app = AsyncMock(return_value=mock_services)
 
-    with patch("main.get_app", new=AsyncMock(return_value=mock_app_data)):
+    with patch("main.getApp", new=AsyncMock(return_value=mock_app_data)):
         with pytest.raises(Exception) as excinfo:
-            await create_vhost("test-app", "nonexistent-service", "test-account")
+            await createVhost("test-app", "nonexistent-service", "test-account")
 
         mock_service_manager.list_by_app.assert_called_once_with(1)
         assert (
@@ -1129,7 +1129,7 @@ async def test_delete_vhost(mock_vhost_manager):
 
     mock_vhost_manager.delete_vhost = AsyncMock()
 
-    await delete_vhost(42)
+    await deleteVhost(42)
     mock_vhost_manager.delete_vhost.assert_called_once_with(42)
 
 
@@ -1177,8 +1177,8 @@ async def test_list_services(mock_service_manager):
 
     mock_service_manager.list_by_app = AsyncMock(return_value=mock_services)
 
-    with patch("main.get_app", new=AsyncMock(return_value=mock_app_data)):
-        result = await list_services("test-app", "test-account")
+    with patch("main.getApp", new=AsyncMock(return_value=mock_app_data)):
+        result = await listServices("test-app", "test-account")
 
         mock_service_manager.list_by_app.assert_called_once_with(1)
 
@@ -1197,9 +1197,9 @@ async def test_list_services_app_not_found():
     Test list_services raises an exception when app is not found.
     """
 
-    with patch("main.get_app", new=AsyncMock(return_value=None)):
+    with patch("main.getApp", new=AsyncMock(return_value=None)):
         with pytest.raises(Exception) as excinfo:
-            await list_services("nonexistent-app", "test-account")
+            await listServices("nonexistent-app", "test-account")
 
         assert "App nonexistent-app not found" in str(excinfo.value)
 
@@ -1234,8 +1234,8 @@ async def test_get_service_success(mock_service_manager):
 
     mock_service_manager.get_by_handle_and_app = AsyncMock(return_value=mock_service)
 
-    with patch("main.get_app", new=AsyncMock(return_value=mock_app_data)):
-        result = await get_service("test-app", "web", "test-account")
+    with patch("main.getApp", new=AsyncMock(return_value=mock_app_data)):
+        result = await getService("test-app", "web", "test-account")
 
         mock_service_manager.get_by_handle_and_app.assert_called_once_with("web", 1)
 
@@ -1251,9 +1251,9 @@ async def test_get_service_app_not_found():
     Test get_service raises an exception when app is not found.
     """
 
-    with patch("main.get_app", new=AsyncMock(return_value=None)):
+    with patch("main.getApp", new=AsyncMock(return_value=None)):
         with pytest.raises(Exception) as excinfo:
-            await get_service("nonexistent-app", "web", "test-account")
+            await getService("nonexistent-app", "web", "test-account")
 
         assert "App nonexistent-app not found" in str(excinfo.value)
 
@@ -1275,9 +1275,9 @@ async def test_get_service_not_found(mock_service_manager):
 
     mock_service_manager.get_by_handle_and_app = AsyncMock(return_value=None)
 
-    with patch("main.get_app", new=AsyncMock(return_value=mock_app_data)):
+    with patch("main.getApp", new=AsyncMock(return_value=mock_app_data)):
         with pytest.raises(Exception) as excinfo:
-            await get_service("test-app", "nonexistent-service", "test-account")
+            await getService("test-app", "nonexistent-service", "test-account")
 
         mock_service_manager.get_by_handle_and_app.assert_called_once_with(
             "nonexistent-service", 1
@@ -1320,8 +1320,8 @@ async def test_scale_service_success(mock_service_manager):
 
     mock_service_manager.scale = AsyncMock(return_value=mock_updated_service)
 
-    with patch("main.get_service", new=AsyncMock(return_value=mock_service_data)):
-        result = await scale_service(
+    with patch("main.getService", new=AsyncMock(return_value=mock_service_data)):
+        result = await scaleService(
             "test-app",
             "web",
             container_count=4,
@@ -1343,7 +1343,7 @@ async def test_scale_service_no_parameters():
     Test scale_service raises an exception when no scaling parameters are provided.
     """
     with pytest.raises(ValueError) as excinfo:
-        await scale_service("test-app", "web", account_handle="test-account")
+        await scaleService("test-app", "web", account_handle="test-account")
 
     assert "Must specify at least one of container_count or container_size" in str(
         excinfo.value
@@ -1392,13 +1392,13 @@ async def test_list_service_vhosts(mock_vhost_manager):
 
     mock_vhost_manager.list_by_service = AsyncMock(return_value=mock_vhosts)
 
-    with patch("main.get_service", new=AsyncMock(return_value=mock_service_data)):
+    with patch("main.getService", new=AsyncMock(return_value=mock_service_data)):
         with patch("main.Service.model_validate") as mock_validate:
             mock_service = Mock()
             mock_service.id = 1
             mock_validate.return_value = mock_service
 
-            result = await list_service_vhosts("test-app", "web", "test-account")
+            result = await listServiceVhosts("test-app", "web", "test-account")
 
             mock_vhost_manager.list_by_service.assert_called_once_with(1)
 


### PR DESCRIPTION
Sorry that this PR does two things. I have been working on the Operations piece whenever I have downtime, and it ended up getting munged with the other MCP work. Prior to the examples, AI would do some pretty wildly wrong things, especially for the .aptible.yml file. With these changes, it's generating things that are at least syntactically correct, even if they're not perfect. 



Example of Claude pulling and using examples (I made a slight tweak to the description to correct for the fact that migrations do not belong here): 
<img width="833" height="686" alt="Screenshot 2025-09-18 at 1 18 06 PM" src="https://github.com/user-attachments/assets/2c0e5f21-b233-4f5a-b8a6-ed74806bc896" />


Example of Claude using operation logs for debugging:
<img width="739" height="341" alt="Screenshot 2025-09-18 at 1 20 48 PM" src="https://github.com/user-attachments/assets/ad0bab6c-83d3-4140-8292-5c38fb1f7c7c" />

And operation lookup/debugging:
<img width="736" height="326" alt="Screenshot 2025-09-18 at 1 21 21 PM" src="https://github.com/user-attachments/assets/0478240b-4972-406e-b2e9-e606b6f85565" />



